### PR TITLE
README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ override func tearDownWithError() throws {
 }
 ```
 ### Your first test
-In the tests body add invocations of `application.accessibilityAnalyze()` or `application.evAnalyze()` over `XCUIApplication` instance of the tested app at the places/states of the app you want to test. A good place to add testing may be after simulating taps or screen change.
+In the tests body add invocations of `application.evAnalyze()` over `XCUIApplication` instance of the tested app at the places/states of the app you want to test. A good place to add testing may be after simulating taps or screen change.
 After that just run your test suite(s).
 
 #### Async usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In order to use any of the Evinced Mobile SDKs you first need to create an [Evin
 If an outbound internet connection is not available in your running environment - contact us at support@evinced.com to get an offline APIKey.
 
 You should have any UI testing set up for your application with usage of pure XCUITest SDK.
-You should add `EvincedXCUISDK` wether via [Cocoapods](https://cocoapods.org/) or [Swift Package Manager](https://swift.org/package-manager/) to your UI tests target.
+You should add `EvincedXCUISDK` whether via [Cocoapods](https://cocoapods.org/) or [Swift Package Manager](https://swift.org/package-manager/) to your UI tests target.
 
 #### Cocoapods
 1. Add the following line you your UI Test target in `Podfile`: `pod 'EvincedXCUISDK'`
@@ -23,7 +23,7 @@ Using Swift Package Manager is preferable.
 2. Select your UI tests target `EvincedXCUISDK` to link with.
 
 ### Setup
-In order to setup `EvincedXCUISDK` you will need to add the followin code to setup and teardown methods in your tests, jsut like this:
+In order to setup `EvincedXCUISDK` you will need to add the following code to setup and teardown methods in your tests, just like this:
 
 ```
 override func setUpWithError() throws {
@@ -37,31 +37,31 @@ override func setUpWithError() throws {
 ```
 override func tearDownWithError() throws {
     // This method will validate the stored accessibility data and generate an HTML report without failing the test.
-    
-    // Use flag `assert: true` if you prefert to fail the test if an accessibility issue is found.    
+
+    // Use flag `assert: true` if you prefer to fail the test if an accessibility issue is found.    
     try EvincedEngine.reportStored(assert: false)
-    
+
     // Other tear down code...
 }
 ```
 ### Your first test
-In the tests body add invocations of `application.accessibilityAnalize()` or `application.evAnalyze()` over `XCUIApplication` instance of the tested app at the places/states of the app you want to test. A good place to add testing may be after simulatin taps or screen change.
+In the tests body add invocations of `application.accessibilityAnalyze()` or `application.evAnalyze()` over `XCUIApplication` instance of the tested app at the places/states of the app you want to test. A good place to add testing may be after simulating taps or screen change.
 After that just run your test suite(s).
 
 #### Async usage
-Due to known limitations of Aplle platform, please use public interface in background threads and async calls with care. Please make shure you use `XCTestExpectation` in async calls:
+Due to known limitations of Apple platform, please use public interface in background threads and async calls with care. Please make sure you use `XCTestExpectation` in async calls:
 ```
 let expectation = expectation(description: "Accessibility analyze")
 DispatchQueue.main.async {
     try app.evAnalyze()
-    
+
     expectation.fulfill()
 }
 waitForExpectations(timeout: 5.0)
 ```
 
 ### The Evinced Report
-After the test finhishes `EvincedEngine.reportStored(assert:)` would generate accessibility HTML reports which are stored as [test attachments](https://developer.apple.com/documentation/xctest/activities_and_attachments/adding_attachments_to_tests_activities_and_issues). You could check and save them via Xcode GUI or `xcrun xcresulttool ...` CLI command.
+After the test finishes `EvincedEngine.reportStored(assert:)` would generate accessibility HTML reports which are stored as [test attachments](https://developer.apple.com/documentation/xctest/activities_and_attachments/adding_attachments_to_tests_activities_and_issues). You could check and save them via Xcode GUI or `xcrun xcresulttool ...` CLI command.
 
 ### Documentation
-Please see our official [XCUI SDK](https://developer.evinced.com/sdks-for-mobile-apps/xcuitest-sdk) documentation page for more details and examples. 
+Please see our official [XCUI SDK](https://developer.evinced.com/sdks-for-mobile-apps/xcuitest-sdk) documentation page for more details and examples.


### PR DESCRIPTION
- Several typos fixes in the `README.md` file
- Removal of `application.accessibilityAnalyze()` from `README.md` since it as deprecated