### PR TITLE
chore: realign CODEOWNERS team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@GetEvinced/mobile-ios
+@GetEvinced/mobile-sdk


### PR DESCRIPTION
Realigns CODEOWNERS team references after the GitHub team restructure into the `engineering` hierarchy.

Approved remap (workspace-admin-toolkit `docs/codeowners-remap-2026-05-21.md`):
- `@GetEvinced/web-apollo` -> `@GetEvinced/core-and-sdk`
- `@GetEvinced/mobile-android` / `@GetEvinced/mobile-ios` -> `@GetEvinced/mobile-sdk`
- `@GetEvinced/infra-cloud` -> `@GetEvinced/cloud`
- `@GetEvinced/qa` / `@GetEvinced/qa-group` -> `@GetEvinced/qa-team`
- `@GetEvinced/gen-ai-products` -> `@GetEvinced/agentic-tools`
- `@GetEvinced/backend-infra` -> `@GetEvinced/cloud`
- `@GetEvinced/mobile-mfa` -> `@GetEvinced/mobile-engine`
